### PR TITLE
Update uuid to version 3.0.0

### DIFF
--- a/newId.js
+++ b/newId.js
@@ -1,1 +1,1 @@
-module.exports = require('node-uuid').v4;
+module.exports = require('uuid').v4;

--- a/package.json
+++ b/package.json
@@ -20,10 +20,10 @@
     "deferred": "^0.7.4",
     "generic-pool": "^2.2.2",
     "mysql": "^2.10.0",
-    "node-uuid": "^1.4.7",
     "pg": "6.0.3",
     "pg-query-stream": "^1.0.0",
-    "promise": "^6.1.0"
+    "promise": "^6.1.0",
+    "uuid": "^3.0.0"
   },
   "devDependencies": {
     "a": "^2.1.0"


### PR DESCRIPTION
## Version 3.0.0 of [uuid](https://github.com/kelektiv/node-uuid) just got published.

Hi there,

This week a new version of the [uuid](https://github.com/kelektiv/node-uuid) module got released. The old module which was available by the name [node-uuid](https://www.npmjs.com/package/node-uuid) got deprecated and will show error message upon every install of the module.

To get rid of those install errors I've created this **automated pull request**. I've run some checks against your code base to test whether you're using one of the [deprecated apis](https://github.com/kelektiv/node-uuid/commit/5ae7287fc935eb55ef39133e4be17ef623ca000e), but this isn't the case.


Please test the changes against your code. I didn't run any tests and therefore can't guarantee that it isn't breaking. You can also just close this pr if you don't want to update your module.

In case there's already another pr open to upgrade uuid, I'm sorry for the effort I'm causing.