### PR TITLE
Allow lock to take a function as parameter

### DIFF
--- a/lock.js
+++ b/lock.js
@@ -1,10 +1,26 @@
 var query = require('./query');
 var toIntKey = require('./lock/toIntKey');
 
-function lock(key) {
-	key = toIntKey(key);
-	var sql = 'SELECT pg_advisory_xact_lock(' + key + ')';
-	return query(sql);
+function lock(key, func) {
+    key = toIntKey(key);
+    if(typeof func === 'function') {
+        return inLock(key, func);
+    } else {
+        var sql = 'SELECT pg_advisory_xact_lock(' + key + ')';
+        return query(sql);
+    }
+}
+
+async function inLock(key, func) {
+    await query('SELECT pg_advisory_lock(' + key + ')');
+    try {
+        let result = await func();
+        await query('SELECT pg_advisory_unlock(' + key + ')');
+        return result;
+    } catch(e) {
+        await query('SELECT pg_advisory_unlock(' + key + ')');
+        throw e;
+    }
 }
 
 module.exports = lock;

--- a/lockSpec/req/lockFunc.js
+++ b/lockSpec/req/lockFunc.js
@@ -1,0 +1,13 @@
+async function act(c){
+	c.key = 1234567890;
+	c.intKey = '<intKey>';
+	c.toIntKey.expect(c.key).return(c.intKey);
+
+	c.query.expect('SELECT pg_advisory_lock(<intKey>)').return();
+	c.query.expect('SELECT pg_advisory_unlock(<intKey>)').return();
+	
+	c.expected = {};
+	c.returned = await c.sut(c.key, () => c.expected);
+}
+
+module.exports = act;

--- a/lockSpec/req/lockFuncError.js
+++ b/lockSpec/req/lockFuncError.js
@@ -1,0 +1,18 @@
+async function act(c){
+	c.key = 1234567890;
+	c.intKey = '<intKey>';
+	c.toIntKey.expect(c.key).return(c.intKey);
+
+	c.query.expect('SELECT pg_advisory_lock(<intKey>)').return();
+	c.query.expect('SELECT pg_advisory_unlock(<intKey>)').return();
+	
+	c.error = new Error();
+	c.expected = {};
+	try {
+		c.returned = await c.sut(c.key, async () => { throw c.error });
+	} catch(e) {
+		c.caughtError = e;
+	}
+}
+
+module.exports = act;

--- a/lockSpec/req/whenLockFunc.js
+++ b/lockSpec/req/whenLockFunc.js
@@ -1,0 +1,7 @@
+var when = require('a').when;
+var c = {};
+
+when(c).then(it => {
+	it('should both lock and unlock').assertDoesNotThrow(c.query.verify)
+	it('should return result from function').assertEqual(c.expected, c.returned)
+});

--- a/lockSpec/req/whenLockFuncError.js
+++ b/lockSpec/req/whenLockFuncError.js
@@ -1,0 +1,7 @@
+var when = require('a').when;
+var c = {};
+
+when(c).then(it => {
+	it('should both lock and unlock').assertDoesNotThrow(c.query.verify)
+	it('should return error thrown by function').assertEqual(c.error, c.caughtError)
+});


### PR DESCRIPTION
Lets rdb.lock accept a function as parameter.
The function will only be run when a lock has been acquired. The function is awaited for any return value, then lock is released. The function will then forward the return value from the supplied function.

Code example:
```js
async function longFunction() {
    let orders = getOrders();
    // rdb.lock returns result from inner function when fed a function
    let result = await rdb.lock('123', () => {
        // this code will only run when lock has been acquired.
        let responses = handleOrders(orders);
        return responses;
    });
    // this code will run after lock has been released
    sendNotificationToCustomers(orders, results);
}
```