### PR TITLE
Fix DTO duplicates bug

### DIFF
--- a/patchTable.js
+++ b/patchTable.js
@@ -20,7 +20,7 @@ async function patchTable(table, patches, { defaultConcurrency = 'optimistic', c
 			row = row || await table.tryGetById(property);
 		if (path.length === 0) {
 			let pkName = table._primaryColumns[0].alias;
-			row = table.insert(property[pkName]);
+			row = table.insert(value[pkName]);
 			for (let name in value) {
 				row[name] = fromCompareObject(value[name]);
 			}


### PR DESCRIPTION
Fix bug that leads to duplicates in DTO from new patched tables, where the patch is an insert in a related table.
Fixed by properly getting the private key value from the patch.