### PR TITLE
fix: resolve object equality bug in JSON patch validation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "orange-orm",
-    "version": "5.3.5-beta-0",
+    "version": "5.3.6",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "orange-orm",
-            "version": "5.3.5-beta-0",
+            "version": "5.3.6",
             "license": "ISC",
             "dependencies": {
                 "@cloudflare/workers-types": "^4.20241106.0",

--- a/src/applyPatch.js
+++ b/src/applyPatch.js
@@ -115,28 +115,25 @@ function assertDeepEqual(a, b) {
 
 function deepEqual(a, b) {
 	if (a === b) return true;
-	if (a instanceof Date && b instanceof Date) return a.getTime() === b.getTime();
 	if (a && b && typeof a === 'object' && typeof b === 'object') {
-		if (a.constructor !== b.constructor) return false;
 		if (Array.isArray(a)) {
-			if (a.length !== b.length) return false;
+			if (!Array.isArray(b) || a.length !== b.length) return false;
 			for (let i = 0; i < a.length; i++) {
 				if (!deepEqual(a[i], b[i])) return false;
 			}
 			return true;
 		}
+		if (Array.isArray(b)) return false;
+
 		const keysA = Object.keys(a);
 		const keysB = Object.keys(b);
 		if (keysA.length !== keysB.length) return false;
 		for (const key of keysA) {
-			if (!Object.prototype.hasOwnProperty.call(b, key)) return false;
-		}
-		for (const key of keysA) {
-			if (!deepEqual(a[key], b[key])) return false;
+			if (!Object.prototype.hasOwnProperty.call(b, key) || !deepEqual(a[key], b[key])) return false;
 		}
 		return true;
 	}
-	return a !== a && b !== b; // Handle NaN
+	return false;
 }
 
 module.exports = applyPatch;

--- a/src/applyPatch.js
+++ b/src/applyPatch.js
@@ -108,27 +108,35 @@ function applyPatch({ options = {}, context }, dto, changes, column) {
 
 }
 
-// function assertDatesEqual(date1, date2) {
-// 	if (date1 && date2) {
-// 		const parts1 = date1.split('T');
-// 		const time1parts = (parts1[1] || '').split(/[-+.]/);
-// 		const parts2 = date2.split('T');
-// 		const time2parts = (parts2[1] || '').split(/[-+.]/);
-// 		while (time1parts.length !== time2parts.length) {
-// 			if (time1parts.length > time2parts.length)
-// 				time1parts.pop();
-// 			else if (time1parts.length < time2parts.length)
-// 				time2parts.pop();
-// 		}
-// 		date1 = `${parts1[0]}T${time1parts[0]}`;
-// 		date2 = `${parts2[0]}T${time2parts[0]}`;
-// 	}
-// 	assertDeepEqual(date1, date2);
-// }
-
 function assertDeepEqual(a, b) {
-	if (JSON.stringify(a) !== JSON.stringify(b))
+	if (!deepEqual(a, b))
 		throw new Error('A, b are not equal');
+}
+
+function deepEqual(a, b) {
+	if (a === b) return true;
+	if (a instanceof Date && b instanceof Date) return a.getTime() === b.getTime();
+	if (a && b && typeof a === 'object' && typeof b === 'object') {
+		if (a.constructor !== b.constructor) return false;
+		if (Array.isArray(a)) {
+			if (a.length !== b.length) return false;
+			for (let i = 0; i < a.length; i++) {
+				if (!deepEqual(a[i], b[i])) return false;
+			}
+			return true;
+		}
+		const keysA = Object.keys(a);
+		const keysB = Object.keys(b);
+		if (keysA.length !== keysB.length) return false;
+		for (const key of keysA) {
+			if (!Object.prototype.hasOwnProperty.call(b, key)) return false;
+		}
+		for (const key of keysA) {
+			if (!deepEqual(a[key], b[key])) return false;
+		}
+		return true;
+	}
+	return a !== a && b !== b; // Handle NaN
 }
 
 module.exports = applyPatch;

--- a/tests/applyPatch.test.js
+++ b/tests/applyPatch.test.js
@@ -10,7 +10,7 @@ describe('applyPatch structural equality with different key order', () => {
 		const changes = [
 			{ op: 'replace', path: '/data', value: toCompareObject({ a: 1, b: 2, c: 3 }), oldValue: toCompareObject({ b: 2, a: 1 }) }
 		];
-		
+
 		const result = applyPatch({ options: {}, context }, dto, changes, column);
 		expect(result.data).toEqual({ a: 1, b: 2, c: 3 });
 	});
@@ -22,7 +22,7 @@ describe('applyPatch structural equality with different key order', () => {
 		const changes = [
 			{ op: 'replace', path: '/data', value: toCompareObject({ a: 1, b: 2, c: 3 }), oldValue: toCompareObject({ b: 3, a: 1 }) }
 		];
-		
+
 		expect(() => {
 			applyPatch({ options: {}, context }, dto, changes, column);
 		}).toThrow('The row was changed by another user.');

--- a/tests/applyPatch.test.js
+++ b/tests/applyPatch.test.js
@@ -1,0 +1,55 @@
+import { describe, test, expect } from 'vitest';
+const applyPatch = require('../src/applyPatch');
+const toCompareObject = require('../src/toCompareObject');
+
+describe('applyPatch structural equality with different key order', () => {
+	test('different key order', () => {
+		const context = { rdb: { engine: 'sap' } };
+		const column = { tsType: 'JSONColumn' };
+		const dto = { data: { a: 1, b: 2 } };
+		const changes = [
+			{ op: 'replace', path: '/data', value: toCompareObject({ a: 1, b: 2, c: 3 }), oldValue: toCompareObject({ b: 2, a: 1 }) }
+		];
+		
+		const result = applyPatch({ options: {}, context }, dto, changes, column);
+		expect(result.data).toEqual({ a: 1, b: 2, c: 3 });
+	});
+
+	test('conflict error when structurally different', () => {
+		const context = { rdb: { engine: 'sap' } };
+		const column = { tsType: 'JSONColumn' };
+		const dto = { data: { a: 1, b: 2 } };
+		const changes = [
+			{ op: 'replace', path: '/data', value: toCompareObject({ a: 1, b: 2, c: 3 }), oldValue: toCompareObject({ b: 3, a: 1 }) }
+		];
+		
+		expect(() => {
+			applyPatch({ options: {}, context }, dto, changes, column);
+		}).toThrow('The row was changed by another user.');
+	});
+
+	test('deeply nested structures different order', () => {
+		const context = { rdb: { engine: 'sap' } };
+		const column = { tsType: 'JSONColumn' };
+		const dto = { data: { x: [1, { y: 2, z: 3 }] } };
+		const changes = [
+			{ op: 'replace', path: '/data', value: toCompareObject({ x: [1, { y: 2, z: 4 }] }), oldValue: toCompareObject({ x: [1, { z: 3, y: 2 }] }) }
+		];
+
+		const result = applyPatch({ options: {}, context }, dto, changes, column);
+		expect(result.data).toEqual({ x: [1, { y: 2, z: 4 }] });
+	});
+
+	test('fails if nested structures are different', () => {
+		const context = { rdb: { engine: 'sap' } };
+		const column = { tsType: 'JSONColumn' };
+		const dto = { data: { x: [1, { y: 2, z: 3 }] } };
+		const changes = [
+			{ op: 'replace', path: '/data', value: toCompareObject({ x: [1, { y: 2, z: 4 }] }), oldValue: toCompareObject({ x: [1, { z: 3, y: 5 }] }) }
+		];
+
+		expect(() => {
+			applyPatch({ options: {}, context }, dto, changes, column);
+		}).toThrow('The row was changed by another user.');
+	});
+});

--- a/tests/conflicts.test.js
+++ b/tests/conflicts.test.js
@@ -16,11 +16,7 @@ let server;
 
 
 beforeAll(async () => {
-	try {
-		await createMs('mssql');
-	} catch (e) {
-		console.warn('Could not connect to mssql, skipping mssql database setup.');
-	}
+	await createMs('mssql');
 	hostExpress();
 
 	async function createMs(dbName) {
@@ -90,6 +86,7 @@ describe('optimistic fail', () => {
 				id: 1,
 				name: 'George',
 				balance: 177,
+				isActive: true
 			});
 		}
 		catch (e) {
@@ -153,49 +150,13 @@ describe('optimistic json object', () => {
 	}
 });
 
-describe('optimistic json object different key order', () => {
-	test('sap', async () => await verify('sap'));
-
-	async function verify(dbName) {
-		let { db, init } = getDb(dbName);
-		await init(db);
-
-		const customer = await db.customer2.insert({
-			name: 'Voldemort',
-			balance: -200,
-			isActive: true,
-			picture: null,
-			data: { a: 1, b: 2 },
-		});
-
-		const customer2 = await db.customer2.getById(customer.id);
-		customer2.data = { b: 2, a: 1 };
-		customer2.name = 'Voldemort2';
-		await customer2.saveChanges();
-
-		customer.name = 'Voldemort3';
-		await customer.saveChanges();
-
-		const expected = {
-			id: customer.id,
-			name: 'Voldemort3',
-			balance: -200,
-			isActive: true,
-			picture: null,
-			data: { b: 2, a: 1 }
-		};
-
-		expect(customer).toEqual(expected);
-	}
-});
-
 describe('add property to JSON', () => {
 	test('pg', async () => await verify('pg'));
 	test('pglite', async () => await verify('pglite'));
 	test('oracle', async () => await verify('oracle'));
 	test('mssql', async () => await verify('mssql'));
 	if (major === 18)
-		test('mssqlNative', async () => await verify('verifyMsNative'));
+		test('mssqlNative', async () => await verify('mssqlNative'));
 	test('mysql', async () => await verify('mysql'));
 	test('mariadb', async () => await verify('mariadb'));
 	test('sqlite', async () => await verify('sqlite'));

--- a/tests/conflicts.test.js
+++ b/tests/conflicts.test.js
@@ -16,7 +16,11 @@ let server;
 
 
 beforeAll(async () => {
-	await createMs('mssql');
+	try {
+		await createMs('mssql');
+	} catch (e) {
+		console.warn('Could not connect to mssql, skipping mssql database setup.');
+	}
 	hostExpress();
 
 	async function createMs(dbName) {
@@ -143,6 +147,42 @@ describe('optimistic json object', () => {
 			isActive: true,
 			picture: null,
 			data: {foo: 1, bar: {baz: {bar: 'changedBy2', zeta: 'changedBy1'}}},
+		};
+
+		expect(customer).toEqual(expected);
+	}
+});
+
+describe('optimistic json object different key order', () => {
+	test('sap', async () => await verify('sap'));
+
+	async function verify(dbName) {
+		let { db, init } = getDb(dbName);
+		await init(db);
+
+		const customer = await db.customer2.insert({
+			name: 'Voldemort',
+			balance: -200,
+			isActive: true,
+			picture: null,
+			data: { a: 1, b: 2 },
+		});
+
+		const customer2 = await db.customer2.getById(customer.id);
+		customer2.data = { b: 2, a: 1 };
+		customer2.name = 'Voldemort2';
+		await customer2.saveChanges();
+
+		customer.name = 'Voldemort3';
+		await customer.saveChanges();
+
+		const expected = {
+			id: customer.id,
+			name: 'Voldemort3',
+			balance: -200,
+			isActive: true,
+			picture: null,
+			data: { b: 2, a: 1 }
 		};
 
 		expect(customer).toEqual(expected);


### PR DESCRIPTION
The validateConflict function in src/applyPatch.js was using JSON.stringify to perform deep equality checks between old and expected values for JSON column updates. This is flawed because JSON.stringify is sensitive to object key order, meaning structurally identical objects could be incorrectly flagged as unequal, causing false-positive concurrency conflicts on the JS-side pre-check.

This change replaces the JSON.stringify-based assertDeepEqual with a robust, order-independent, structural deepEqual function that correctly handles objects, arrays, and primitives. This ensures JS-side correctness for concurrency checks in JSON updates regardless of object key serialization order.

*Note: As noted by the maintainer, this does not solve database-level concurrency conflicts where the database engine itself performs stringified comparisons in the SQL UPDATE WHERE clause (e.g., on SAP ASE). It is intended purely as a correctness improvement for the JS-side validation.*